### PR TITLE
Setup GitHub Actions

### DIFF
--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -1,0 +1,33 @@
+on:
+  push:
+    branches:
+      - akiya/imple-github-actions
+
+jobs:
+  test:
+    name: push test from GitHub Actions
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 1
+      - name: create dummy text
+        run: |
+          touch dummy.txt
+          echo "push test" > dummy.txt
+          ls -la
+      - name: Push
+        run: |
+          git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          `echo git remote -v`
+          `echo git diff --shortstat`
+          git config --global user.name "${GITHUB_ACTOR}"
+          git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          if (git diff --shortstat | grep '[0-9]'); then \
+            git add .; \
+            `echo git status`; \
+            git commit -m "テスト GitHub Actions からプッシュ"; \
+            git push origin HEAD:${GITHUB_REF}; \
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -1,7 +1,7 @@
 on:
   push:
     branches:
-      - akiya/imple-github-actions
+      - main
 jobs:
   build:
     name: Build astro

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -38,16 +38,15 @@ jobs:
           path: static
       - name: Fix .gitignore
         run: sed -i '/static/d' .gitignore
-          ls -la
       - name: Push
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git checkout -b ${TARGET_BRANCH}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add .; \
-          git commit -m "Build at GitHub Actions"; \
-          git push --force origin ${TARGET_BRANCH}; \
+          git add .
+          git commit -m "Build at GitHub Actions"
+          git push --force origin ${TARGET_BRANCH}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: static

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -21,12 +21,8 @@ jobs:
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          `echo git remote -v`
-          if (git diff --shortstat | grep '[0-9]'); then \
-            git add -A; \
-            git commit -m "テスト GitHub Actions からプッシュ"; \
-            `echo git log`; \
-            git push origin HEAD:${GITHUB_REF}; \
-          fi
+          git add -A; \
+          git commit -m "テスト GitHub Actions からプッシュ"; \
+          git push origin HEAD:${GITHUB_REF}; \
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -8,7 +8,7 @@ jobs:
     name: push test from GitHub Actions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@main
         with:
           fetch-depth: 1
       - name: create dummy text

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -16,6 +16,11 @@ jobs:
         run: npm ci
       - name: Build
         run: npm run build
+      - name: Archive static folder
+        uses: actions/upload-artifact@main
+        with:
+          name: static
+          path: static
 
   push:
     name: Push from GitHub Actions
@@ -26,16 +31,18 @@ jobs:
       - uses: actions/checkout@main
         with:
           fetch-depth: 1
-      - name: create dummy text
+      - name: Download artifact
+        uses: actions/download-artifact@main
+        with:
+          name: static
+          path: static
+      - name: check files
         run: |
-          touch dummy.txt
-          echo "push test" > dummy.txt
           ls -la
       - name: Push
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git checkout -b ${TARGET_BRANCH}
-          git fetch
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add -A; \

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -22,12 +22,10 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           `echo git remote -v`
-          `echo git status --short`
-          `echo git diff --shortstat`
           if (git diff --shortstat | grep '[0-9]'); then \
-            `echo git status`; \
             git add -A; \
             git commit -m "テスト GitHub Actions からプッシュ"; \
+            `echo git log`; \
             git push origin HEAD:${GITHUB_REF}; \
           fi
         env:

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -35,6 +35,7 @@ jobs:
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
           git checkout -b ${TARGET_BRANCH}
+          git fetch
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add -A; \

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -3,8 +3,8 @@ on:
     branches:
       - akiya/imple-github-actions
 jobs:
-  test:
-    name: push test from GitHub Actions
+  push:
+    name: Push from GitHub Actions
     permissions: write-all
     runs-on: ubuntu-latest
     steps:
@@ -19,10 +19,12 @@ jobs:
       - name: Push
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
+          git checkout -b ${TARGET_BRANCH}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add -A; \
           git commit -m "テスト GitHub Actions からプッシュ"; \
-          git push origin HEAD:${GITHUB_REF}; \
+          git push origin ${TARGET_BRANCH}; \
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TARGET_BRANCH: static

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -45,9 +45,9 @@ jobs:
           git checkout -b ${TARGET_BRANCH}
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
-          git add -A; \
+          git add .; \
           git commit -m "テスト GitHub Actions からプッシュ"; \
-          git push origin ${TARGET_BRANCH}; \
+          git push --force origin ${TARGET_BRANCH}; \
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           TARGET_BRANCH: static

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -36,9 +36,8 @@ jobs:
         with:
           name: static
           path: static
-      - name: check files
-        run: |
-          ls -la
+      - name: Fix .gitignore
+        run: sed -i '/static/d' .gitignore
       - name: Push
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -19,13 +19,14 @@ jobs:
       - name: Push
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
-          `echo git remote -v`
-          `echo git diff --shortstat`
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+          `echo git remote -v`
+          `echo git status --short`
+          `echo git diff --shortstat`
           if (git diff --shortstat | grep '[0-9]'); then \
-            git add .; \
             `echo git status`; \
+            git add -A; \
             git commit -m "テスト GitHub Actions からプッシュ"; \
             git push origin HEAD:${GITHUB_REF}; \
           fi

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -2,10 +2,10 @@ on:
   push:
     branches:
       - akiya/imple-github-actions
-
 jobs:
   test:
     name: push test from GitHub Actions
+    permissions: write-all
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@main

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -3,10 +3,25 @@ on:
     branches:
       - akiya/imple-github-actions
 jobs:
+  build:
+    name: Build astro
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@main
+      - name: Use Node.jobs
+        uses: actions/setup-node@main
+        with:
+          node-version: '16.x'
+      - name: Install dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+
   push:
     name: Push from GitHub Actions
     permissions: write-all
     runs-on: ubuntu-latest
+    needs: build
     steps:
       - uses: actions/checkout@main
         with:

--- a/.github/workflows/push-static.yml
+++ b/.github/workflows/push-static.yml
@@ -38,6 +38,7 @@ jobs:
           path: static
       - name: Fix .gitignore
         run: sed -i '/static/d' .gitignore
+          ls -la
       - name: Push
         run: |
           git remote set-url origin https://github-actions:${GITHUB_TOKEN}@github.com/${GITHUB_REPOSITORY}
@@ -45,7 +46,7 @@ jobs:
           git config --global user.name "${GITHUB_ACTOR}"
           git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
           git add .; \
-          git commit -m "テスト GitHub Actions からプッシュ"; \
+          git commit -m "Build at GitHub Actions"; \
           git push --force origin ${TARGET_BRANCH}; \
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
#1

`main` ブランチにマージまたはプッシュで下記の処理が実行されます

1. GitHub Actions でのビルド
2. `static` フォルダ込みで `static` ブランチへプッシュ

`main` ブランチにプッシュ、マージできる権限のユーザーなら特にユーザー別の設定は不要です。   
GitHub Actions 内でのコミッターは CI を発火させたユーザー = `main` にプッシュ・マージしたアカウントとなります。  